### PR TITLE
Adding animation

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,9 @@
   "predef": [
     "document",
     "window",
-    "-Promise"
+    "-Promise",
+    "$",
+    "Promise"
   ],
   "browser": true,
   "boss": true,

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -53,3 +53,8 @@ body {
   margin-left: 1rem;
 }
 
+.video-player {
+    /* this is overriding a default style from liquid-fire, since we want
+       to let content fly in and out of the container.  */
+    overflow: visible;
+}

--- a/app/templates/video.hbs
+++ b/app/templates/video.hbs
@@ -1,4 +1,4 @@
-{{#liquid-with model as |currentModel|}}
+{{#liquid-with model class='video-player' as |currentModel|}}
   <div style="height: 500px; width: 500px;">
     {{currentModel.snippet.title}}
     <img src={{currentModel.snippet.thumbnails.high.url}} data-video-id={{currentModel.id.videoId}}>

--- a/app/templates/videos.hbs
+++ b/app/templates/videos.hbs
@@ -1,6 +1,6 @@
 <div class="layout">
   <div class="video">
-    {{liquid-outlet}}
+    {{outlet}}
   </div>
   <div class="sidebar">
     {{#each model.items as |item|}}
@@ -11,4 +11,3 @@
     {{/each}}
   </div>
 </div>
-  

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -1,13 +1,13 @@
+let duration = 500;
+
 export default function(){
   this.transition(
-    // this.fromRoute('videos'),
-    // this.toRoute('video'),
-    this.use('explode-from-parent', {
-      matchBy: 'data-video-id',
-      parentSelector: '.layout',
-      childSelector: '.sidebar [data-video-id]',
-      use: ['fly-to', { duration: 300, easing: 'spring'}]
-    }),
-    this.debug()
+    this.hasClass('video-player'),
+    this.use('explode', {
+      pick: 'img',
+      use: ['to-and-from-sidebar', { duration }]
+    }, {
+      use: ['fade', { duration: duration/2 }]
+    })
   );
-};
+}

--- a/app/transitions/to-and-from-sidebar.js
+++ b/app/transitions/to-and-from-sidebar.js
@@ -1,0 +1,23 @@
+export default function toAndFromSidebar(opts={}) {
+  let flyTo = this.lookup('fly-to');
+  return Promise.all([
+    flyTo.call({
+      oldElement: this.oldElement,
+      newElement: matchingThumbnail(this.oldElement)
+    }, { duration: opts.duration, movingSide: 'old' }),
+    flyTo.call({
+      oldElement: matchingThumbnail(this.newElement),
+      newElement: this.newElement
+    }, { duration: opts.duration, movingSide: 'new' })
+  ]);
+}
+
+function matchingThumbnail(image) {
+  let videoId;
+  if (image) {
+    videoId = image.attr('data-video-id');
+  }
+  if (videoId) {
+    return $(`.thumb[data-video-id=${videoId}]`);
+  }
+}


### PR DESCRIPTION
There is one caveat with this implementation: if one of the full-sized images loads too slowly, we may try to measure it before it's available and animate poorly. To workaround, ensure all the images are in cache.
